### PR TITLE
Add source url for JP disposable domains

### DIFF
--- a/.generate
+++ b/.generate
@@ -22,6 +22,7 @@ class disposableHostGenerator():
                   'https://raw.githubusercontent.com/GeroldSetz/emailondeck.com-domains/master/emailondeck.com_domains_from_bdea.cc.txt',
                   'https://getnada.com/api/v1/domains',
                   'https://gist.githubusercontent.com/jamesonev/7e188c35fd5ca754c970e3a1caf045ef/raw/23fba92d2d835928a9217198d5a96b8ea1d52c93/disposableEmailDomains.txt',
+                  'https://raw.githubusercontent.com/daisy1754/jp-disposable-emails/master/list.txt',
                   'https://raw.githubusercontent.com/willwhite/freemail/master/data/disposable.txt',
                   'https://raw.githubusercontent.com/stopforumspam/disposable_email_domains/master/blacklist.txt' ],
         'file': [ 'blacklist.txt' ],


### PR DESCRIPTION
First of all, thanks for this project. I noticed this (and all other disposable domain list I could find online) are often missing widely used Japanese domains. This PR adds one more list so this project can keep adding JP disposable domains. 

Since list is small, If you prefer me to directly edit blacklist.txt, I'll be happy to do so too.