### PR TITLE
Add temp-mail.org domains to blacklist.txt

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -40,3 +40,13 @@ celinecityitalia.com
 digital10network.com
 ivyandmarj.com
 pradajapan.orgpradajapan.orgpradajapan.orgpradajapan.orgpradajapan.orgpradajapan.orgpradajapan.orgpradajapan.orgpradajapan.org
+petloca.com
+alfaceti.com
+goonby.com
+chatich.com
+balaket.com
+bepureme.com
+plexfirm.com
+diolang.com
+wekawa.com
+taukah.com


### PR DESCRIPTION
based on IP: 164.90.252.249

Fixes #64