### PR TITLE
Hubspot list contains too many non-disposable domains

### DIFF
--- a/.generate
+++ b/.generate
@@ -146,7 +146,6 @@ class disposableHostGenerator():
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/FGRibreau/mailchecker/master/list.txt'},
         {'type': 'json', 'src': 'https://raw.githubusercontent.com/ivolo/disposable-email-domains/master/index.json'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/7c/fakefilter/main/txt/data.txt'},
-        {'type': 'list', 'src': 'https://f.hubspotusercontent40.net/hubfs/2832391/Marketing/Lead-Capture/free-domains-2.csv'},
         {'type': 'list', 'src': 'https://getnada.com/api/v1/domains'},
         {'type': 'json', 'src': 'https://mob1.temp-mail.org/request/domains/format/json'},
         {'type': 'json', 'src': 'https://api.internal.temp-mail.io/api/v2/domains'},


### PR DESCRIPTION
Fixes #77

- Remove hubspot list as it contains to many valid domains.