### PR TITLE
Add mozmail.com to whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -115,3 +115,6 @@ asics.com
 
 # https://github.com/disposable/disposable/issues/94
 lendscape.com
+
+# https://github.com/disposable/disposable/issues/97
+mozmail.com


### PR DESCRIPTION
To fix #97, add `mozmail.com` to the whitelist.

When running generate, `mozmail.com` is loaded from https://github.com/stopforumspam/disposable_email_domains. I've opened https://github.com/stopforumspam/disposable_email_domains/pull/1 to remove it, but since that repo hasn't been touched since October 2020, I'm not hopeful that it will be accepted.