### PR TITLE
Switch stopforumspam from repo to download

### DIFF
--- a/.generate
+++ b/.generate
@@ -140,7 +140,7 @@ class disposableHostGenerator():
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/disposable/disposable/master/blacklist.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/GeroldSetz/emailondeck.com-domains/master/emailondeck.com_domains_from_bdea.cc.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/willwhite/freemail/master/data/disposable.txt'},
-        {'type': 'list', 'src': 'https://raw.githubusercontent.com/stopforumspam/disposable_email_domains/master/blacklist.txt'},
+        {'type': 'list', 'src': 'https://www.stopforumspam.com/downloads/toxic_domains_whole.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/martenson/disposable-email-domains/master/disposable_email_blocklist.conf'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/daisy1754/jp-disposable-emails/master/list.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/FGRibreau/mailchecker/master/list.txt'},


### PR DESCRIPTION
Use the "toxic domains (exact name match)" list from https://www.stopforumspam.com/downloads, rather than the stale github repo https://github.com/stopforumspam/disposable_email_domains (last updated August 2020).

There are _many_ difference between the files. It looks like the file hosted on https://www.stopforumspam.com/downloads does not have domains that are no longer in DNS, and has added more entries. I know at least one list (https://github.com/kslr/disposable-email-domains) that uses this download at the source.