### PR TITLE
add icam.fr to whitelist.txt

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -118,3 +118,6 @@ lendscape.com
 
 # https://github.com/disposable/disposable/issues/97
 mozmail.com
+
+# French university, e.g. <first>.<last-name>@2028.icam.fr
+icam.fr


### PR DESCRIPTION
https://www.icam.fr/ is a university in France. They issue addresses to all students on a first-name.last-name@ basis

Source map says it's auto-imported from https://www.stopforumspam.com which isn't necessarily collecting disposable email domains.