### PR TITLE
Add flotwig/disposable-email-addresses

### DIFF
--- a/.generate
+++ b/.generate
@@ -145,6 +145,7 @@ class disposableHostGenerator():
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/FGRibreau/mailchecker/master/list.txt'},
         {'type': 'json', 'src': 'https://raw.githubusercontent.com/ivolo/disposable-email-domains/master/index.json'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/7c/fakefilter/main/txt/data.txt'},
+        {'type': 'list', 'src': 'https://raw.githubusercontent.com/flotwig/disposable-email-addresses/master/domains.txt'},
         {'type': 'list', 'src': 'https://getnada.com/api/v1/domains'},
         {'type': 'json', 'src': 'https://mob1.temp-mail.org/request/domains/format/json'},
         {'type': 'json', 'src': 'https://api.internal.temp-mail.io/api/v2/domains'},

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Fetched 5196 domains and 6593 hashes
 |https://github.com/FGRibreau/mailchecker/|![GitHub last commit](https://img.shields.io/github/last-commit/FGRibreau/mailchecker)|
 |https://github.com/ivolo/disposable-email-domains/|![GitHub last commit](https://img.shields.io/github/last-commit/ivolo/disposable-email-domains)|
 |https://github.com/7c/fakefilter/|![GitHub last commit](https://img.shields.io/github/last-commit/7c/fakefilter)|
+|https://github.com/flotwig/disposable-email-addresses/|![GitHub last commit](https://img.shields.io/github/last-commit/flotwig/disposable-email-addresses)|
 |https://www.rotvpn.com/en/disposable-email||
 
 ## Credits


### PR DESCRIPTION
This list was created with the same purpose as this project and adds some new domains to the existing list.

Once this is merged I'll add a linkback from my repo to this project, since this project is much more comprehensive.