### PR TITLE
Remove outdated sources

### DIFF
--- a/.generate
+++ b/.generate
@@ -134,8 +134,6 @@ class disposableHostGenerator():
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/disposable/static-disposable-lists/master/mail-data-hosts-net.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/wesbos/burner-email-providers/master/emails.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/disposable/disposable/master/blacklist.txt'},
-        {'type': 'list', 'src': 'https://raw.githubusercontent.com/GeroldSetz/emailondeck.com-domains/master/emailondeck.com_domains_from_bdea.cc.txt'},
-        {'type': 'list', 'src': 'https://raw.githubusercontent.com/willwhite/freemail/master/data/disposable.txt'},
         {'type': 'list', 'src': 'https://www.stopforumspam.com/downloads/toxic_domains_whole.txt'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/martenson/disposable-email-domains/master/disposable_email_blocklist.conf'},
         {'type': 'list', 'src': 'https://raw.githubusercontent.com/daisy1754/jp-disposable-emails/master/list.txt'},

--- a/README.md
+++ b/README.md
@@ -86,12 +86,9 @@ Fetched 5196 domains and 6593 hashes
 |Source|Status|
 |------|--:|
 |https://gist.github.com/adamloving/4401361/|![GitHub last update](https://img.shields.io/badge/dynamic/json?color=lightgray&style=flat&label=last%20update&query=%24.updated_at&url=https%3A%2F%2Fapi.github.com%2Fgists%2F4401361&cacheSeconds=86400)|
-|https://gist.github.com/michenriksen/8710649/|![GitHub last update](https://img.shields.io/badge/dynamic/json?color=lightgray&style=flat&label=last%20update&query=%24.updated_at&url=https%3A%2F%2Fapi.github.com%2Fgists%2F8710649&cacheSeconds=86400)|
 |https://gist.github.com/jamesonev/7e188c35fd5ca754c970e3a1caf045ef/|![GitHub last update](https://img.shields.io/badge/dynamic/json?color=lightgray&style=flat&label=last%20update&query=%24.updated_at&url=https%3A%2F%2Fapi.github.com%2Fgists%2F7e188c35fd5ca754c970e3a1caf045ef&cacheSeconds=86400)|
 |https://github.com/disposable/static-disposable-lists/|![GitHub last commit](https://img.shields.io/github/last-commit/disposable/static-disposable-lists)|
 |https://github.com/wesbos/burner-email-providers/|![GitHub last commit](https://img.shields.io/github/last-commit/wesbos/burner-email-providers)|
-|https://github.com/GeroldSetz/emailondeck.com-domains/| ![GitHub last commit](https://img.shields.io/github/last-commit/GeroldSetz/emailondeck.com-domains) |
-|https://github.com/willwhite/freemail/|![GitHub last commit](https://img.shields.io/github/last-commit/willwhite/freemail)|
 |https://github.com/stopforumspam/disposable_email_domains/|![GitHub last commit](https://img.shields.io/github/last-commit/stopforumspam/disposable_email_domains)|
 |https://github.com/martenson/disposable-email-domains/|![GitHub last commit](https://img.shields.io/github/last-commit/martenson/disposable-email-domains)|
 |https://github.com/daisy1754/jp-disposable-emails/|![GitHub last commit](https://img.shields.io/github/last-commit/daisy1754/jp-disposable-emails)|


### PR DESCRIPTION
Remove following outdated sources:
- https://gist.github.com/michenriksen/8710649/
- https://github.com/GeroldSetz/emailondeck.com-domains
- https://github.com/willwhite/freemail/
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the list of disposable email providers in `.generate` file. Removed `emailondeck.com` and `freemail`, and added `stopforumspam.com`. This change will enhance the accuracy of our disposable email detection.
- Chore: Modified the sources for fetching domains and hashes in `README.md`. Removed `https://gist.github.com/michenriksen/8710649/` and `https://github.com/willwhite/freemail/`. This update ensures we're pulling data from the most reliable and up-to-date sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->