### PR TITLE
Remove Skiff

### DIFF
--- a/greylist.txt
+++ b/greylist.txt
@@ -7,9 +7,6 @@ tutanota.de
 tuta.io
 keemail.me
 
-# skiff
-skiff.com
-
 # protonmail / simplelogin
 protonmail.ch
 proton.me


### PR DESCRIPTION
Skiff is not a burner or disposable email provider. I'm the CEO and happy to answer any questions.

Addresses https://github.com/disposable/disposable/issues/145. 