### PR TITLE
Whitelist 139.com and 189.cn

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -413,5 +413,6 @@ wizard.com
 # private domain - https://github.com/disposable/disposable/issues/235
 centraldecomunicacion.es
 
+# https://github.com/disposable/disposable/pull/243
 139.com
 189.cn


### PR DESCRIPTION
`139.com` is the email service operates by China Mobile and `189.cn` operates by China Telecom. Both of them are legit email services which requires phone number verification to register and use, have a large user group in China, and should not be considered as disposable email services.