### PR TITLE
fix: whitelist forwardemail.net — legitimate email service

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -416,3 +416,7 @@ centraldecomunicacion.es
 # https://github.com/disposable/disposable/pull/243
 139.com
 189.cn
+
+# Forward Email - legitimate open-source email service, not disposable
+# https://forwardemail.net - IMAP/SMTP/CalDAV email hosting for custom domains
+forwardemail.net


### PR DESCRIPTION
forwardemail.net is a legitimate, paid, open-source email service providing full IMAP, SMTP, and CalDAV email hosting for custom domains.  It supports 3M+ domains including major universities, governments, Ubuntu/Canonical, the US Naval Academy, and more.

Adding to whitelist to prevent it from appearing in generated disposable domain lists.

Ref: https://forwardemail.net