### PR TITLE
fix: whitelist improvmx.com — legitimate email forwarding service

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -420,3 +420,7 @@ centraldecomunicacion.es
 # Forward Email - legitimate open-source email service, not disposable
 # https://forwardemail.net - IMAP/SMTP/CalDAV email hosting for custom domains
 forwardemail.net
+
+# ImprovMX - legitimate email forwarding / SMTP service, not disposable
+# https://improvmx.com - permanent email forwarding for custom domains
+improvmx.com


### PR DESCRIPTION
"improvmx.com" is the corporate domain of ImprovMX, a legitimate paid email-forwarding and SMTP service for custom domains. It is **not** a disposable or temporary-email provider — addresses are permanent and tied to real, customer-owned domains used for business mail.

Credibility / scale (all published at https://improvmx.com):
- **Operating since 2013** (over a decade) — a **100% self-funded US company**, **GDPR-compliant**
- **200,000+ users**
- Used in production across DNS registrars, SaaS companies, real-estate brokerages, and customer-support organizations; our clients include Harvard University and Nike.

Ref: https://improvmx.com
